### PR TITLE
Upgrade akkaHttpVersion to 10.1.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,18 +4,13 @@ lazy val root = (project in file(".")).
   settings(
     inThisBuild(List(
       organization := "io.kensu-oss",
-      scalaVersion := "2.12.4",
-      version      := "0.5.0-SNAPSHOT"
+      scalaVersion := "2.11.12",
+      version      := "0.5.0-SNAPSHOT",
+      artifactClassifier := Some(s"akka-http-$akkaHttpBaseVersion")
     )),
     name := "akka-http-pac4j",
-    libraryDependencies ++= Seq(
-      akkaHttp,
-      akkaStreams,
-      pac4j,
-      scalaTestCore % Test,
-      scalacheck % Test,
-      akkaHttpTestKit % Test
-    ),
+    libraryDependencies ++= Dependencies.dependencies,
+
       scalacOptions ++= Seq(
   "-deprecation",           
   "-encoding", "UTF-8",
@@ -36,7 +31,7 @@ lazy val root = (project in file(".")).
     )
   )
 
-crossScalaVersions := Seq("2.11.12", scalaVersion.value)
+crossScalaVersions := Seq("2.12.4", scalaVersion.value)
 
 pgpReadOnly := false
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,17 +1,40 @@
 import sbt._
 
+case class DependencyConfig(
+                             scalacheckVersion: String = "1.13.5",
+                             akkaHttpVersion: String = "10.1.8",
+                             akkaStreamsVersion: String = "2.5.19",
+                             pac4jVersion: String = "3.6.1",
+                             scalaTestVersion: String = "3.0.7"
+                           )
+
 object Dependencies {
-  lazy val scalacheck = "org.scalacheck" %% "scalacheck" % scalacheckVersion
-  lazy val akkaHttp = "com.typesafe.akka" %% "akka-http"   % akkaHttpVersion
-  lazy val akkaHttpTestKit = "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion
-  lazy val akkaStreams = "com.typesafe.akka" %% "akka-stream" % akkaStreamsVersion
-  lazy val pac4j = "org.pac4j" % "pac4j-core" % pac4jVersion
-  lazy val scalaTestCore = "org.scalatest" %% "scalatest" % scalaTestVersion
+  val akkaHttpBaseVersion = System.getProperty("akka-http.version", "10.1")
+  val depsConfig = akkaHttpBaseVersion match {
+    case "10.1" =>
+      DependencyConfig()
 
+    case "10.0" =>
+      DependencyConfig(
+        scalacheckVersion = "1.13.5",
+        akkaHttpVersion = "10.0.11",
+        akkaStreamsVersion = "2.5.8",
+        pac4jVersion = "3.6.1",
+        scalaTestVersion = "3.0.5"
+      )
 
-  val scalacheckVersion = "1.13.5"
-  val akkaHttpVersion = "10.0.11"
-  val akkaStreamsVersion = "2.5.8"
-  val pac4jVersion = "3.6.1"
-  val scalaTestVersion = "3.0.5"
+    case _ => throw new IllegalArgumentException("Unsupported akka-http version")
+  }
+  import depsConfig._
+
+  def dependencies = Seq(
+    "org.scalacheck" %% "scalacheck" % scalacheckVersion % Test,
+    "com.typesafe.akka" %% "akka-http" % akkaHttpVersion,
+    "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion % Test,
+    "com.typesafe.akka" %% "akka-stream-testkit" % akkaStreamsVersion % Test,
+    "com.typesafe.akka" %% "akka-stream" % akkaStreamsVersion,
+    "org.pac4j" % "pac4j-core" % pac4jVersion,
+    "org.scalatest" %% "scalatest" % scalaTestVersion % Test
+  )
+
 }

--- a/src/test/scala/com/stackstate/pac4j/AkkaHttpSecurityTest.scala
+++ b/src/test/scala/com/stackstate/pac4j/AkkaHttpSecurityTest.scala
@@ -150,7 +150,7 @@ class AkkaHttpSecurityTest extends WordSpecLike with Matchers with ScalatestRout
       val postRequest = HttpRequest(
         HttpMethods.POST,
         "/",
-        entity = HttpEntity(ContentType(MediaTypes.`application/x-www-form-urlencoded`, HttpCharsets.`UTF-8`), "username=testuser".getBytes)
+        entity = HttpEntity(ContentType(MediaTypes.`application/x-www-form-urlencoded`, () => HttpCharsets.`UTF-8`), "username=testuser".getBytes)
       )
 
       postRequest ~> akkaHttpSecurity.withFormParameters(enforceFormEncoding = false) { params =>


### PR DESCRIPTION
still supports old akka-http via `sbt -Dakka-http.version=10.0 publishLocal`

cc @samklr